### PR TITLE
Update the play OpenURI path to match mpris casing

### DIFF
--- a/player.go
+++ b/player.go
@@ -18,7 +18,7 @@ const (
 	playerPlayMethod             = playerInterface + ".Play"
 	playerSeekMethod             = playerInterface + ".SeekTo"
 	playerSetPositionMethod      = playerInterface + ".SetPosition"
-	playerOpenURIMethod          = playerInterface + ".OpenURI"
+	playerOpenURIMethod          = playerInterface + ".OpenUri"
 	playerPlaybackStatusProperty = playerInterface + ".PlaybackStatus"
 	playerLoopStatusProperty     = playerInterface + ".LoopStatus"
 	playerRateProperty           = playerInterface + ".Rate"


### PR DESCRIPTION
* the Go pattern for casing of URI differs from the format expected by mpris, causing the OpenURI function not to work properly